### PR TITLE
Add SkyTrade trading client and admin console UIs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true },
+  extends: ['eslint:recommended', 'plugin:react-hooks/recommended'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    'no-console': ['warn', { allow: ['warn', 'error'] }]
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-a
+# SkyTrade Frontend
+
+Modern trading terminal and admin console built with React, Vite, TypeScript, and Material UI for the BackAPI Trading Platform.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs on [http://localhost:5173](http://localhost:5173). Configure environment variables as needed or update `src/api/client.ts` to point to a different API base URL.
+
+## Features
+
+- Authentication flow with JWT persistence
+- Client trading workspace with dashboard, market explorer, orders, portfolio, wallet, and watchlists
+- Admin console to manage users, instruments, wallet adjustments, system telemetry, and access tokens
+- Material UI-based dark theme inspired by pro trading terminals
+- React Query powered data fetching and caching
+- Recharts for performance visualisations

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SkyTrade - Modern Trading Platform</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "trading-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.20",
+    "@mui/material": "^5.15.20",
+    "axios": "^1.6.8",
+    "recharts": "^2.10.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.2",
+    "react-query": "^3.39.3",
+    "react-router-dom": "^6.23.0",
+    "yup": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.62",
+    "@types/react-dom": "^18.2.19",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00b4d8" />
+      <stop offset="100%" stop-color="#0077b6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#grad)" />
+  <path d="M16 40 L28 24 L36 34 L48 18" stroke="#fff" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="48" cy="18" r="4" fill="#fff" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,104 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
+import { CircularProgress, Stack } from '@mui/material';
+import { AuthProvider, useAuth } from './context/AuthContext';
+import MainLayout from './layouts/MainLayout';
+import AdminLayout from './layouts/AdminLayout';
+import LandingPage from './pages/client/LandingPage';
+
+const LoginPage = lazy(() => import('./pages/auth/LoginPage'));
+const RegisterPage = lazy(() => import('./pages/auth/RegisterPage'));
+const ClientDashboard = lazy(() => import('./pages/client/ClientDashboard'));
+const MarketExplorer = lazy(() => import('./pages/client/MarketExplorer'));
+const OrdersPage = lazy(() => import('./pages/client/OrdersPage'));
+const PortfolioPage = lazy(() => import('./pages/client/PortfolioPage'));
+const WalletPage = lazy(() => import('./pages/client/WalletPage'));
+const WatchlistsPage = lazy(() => import('./pages/client/WatchlistsPage'));
+const AdminUsersPage = lazy(() => import('./pages/admin/AdminUsersPage'));
+const AdminInstrumentsPage = lazy(() => import('./pages/admin/AdminInstrumentsPage'));
+const AdminWalletPage = lazy(() => import('./pages/admin/AdminWalletPage'));
+const AdminSystemPage = lazy(() => import('./pages/admin/AdminSystemPage'));
+const AdminAccessTokensPage = lazy(() => import('./pages/admin/AdminAccessTokensPage'));
+
+const Loader = () => (
+  <Stack alignItems="center" justifyContent="center" sx={{ minHeight: '60vh' }}>
+    <CircularProgress color="primary" />
+  </Stack>
+);
+
+const AuthenticatedRoute = ({ children }: { children: JSX.Element }) => {
+  const { token, loading } = useAuth();
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+const AdminRoute = ({ children }: { children: JSX.Element }) => {
+  const { token, user, loading } = useAuth();
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (!token || !user?.roles.includes('admin')) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+function App() {
+  return (
+    <AuthProvider>
+      <Suspense fallback={<Loader />}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+
+          <Route
+            path="/app"
+            element={
+              <AuthenticatedRoute>
+                <MainLayout />
+              </AuthenticatedRoute>
+            }
+          >
+            <Route index element={<ClientDashboard />} />
+            <Route path="market" element={<MarketExplorer />} />
+            <Route path="orders" element={<OrdersPage />} />
+            <Route path="portfolio" element={<PortfolioPage />} />
+            <Route path="wallet" element={<WalletPage />} />
+            <Route path="watchlists" element={<WatchlistsPage />} />
+          </Route>
+
+          <Route
+            path="/admin"
+            element={
+              <AdminRoute>
+                <AdminLayout />
+              </AdminRoute>
+            }
+          >
+            <Route index element={<AdminUsersPage />} />
+            <Route path="instruments" element={<AdminInstrumentsPage />} />
+            <Route path="wallet" element={<AdminWalletPage />} />
+            <Route path="system" element={<AdminSystemPage />} />
+            <Route path="access-tokens" element={<AdminAccessTokensPage />} />
+          </Route>
+
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
+    </AuthProvider>
+  );
+}
+
+export default App;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,42 @@
+import apiClient from './client';
+import type { User } from '../types';
+
+export const getUsers = async () => {
+  const { data } = await apiClient.get('/v1/admin/users');
+  return data.data as User[];
+};
+
+export const approveUser = async (userId: string) => {
+  const { data } = await apiClient.post(`/v1/admin/users/${userId}/approve`);
+  return data.data;
+};
+
+export const blockUser = async (userId: string) => {
+  const { data } = await apiClient.post(`/v1/admin/users/${userId}/block`);
+  return data.data;
+};
+
+export const unblockUser = async (userId: string) => {
+  const { data } = await apiClient.post(`/v1/admin/users/${userId}/unblock`);
+  return data.data;
+};
+
+export const getSystemStats = async () => {
+  const { data } = await apiClient.get('/v1/admin/system/stats');
+  return data.data as {
+    totalUsers: number;
+    activeOrders: number;
+    tradesToday: number;
+    serverLoad: number;
+  };
+};
+
+export const getAdminOrders = async () => {
+  const { data } = await apiClient.get('/v1/admin/orders');
+  return data.data;
+};
+
+export const getAdminTrades = async () => {
+  const { data } = await apiClient.get('/v1/admin/trades');
+  return data.data;
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,38 @@
+import apiClient from './client';
+import type { LoginPayload, RegisterPayload, User } from '../types';
+
+interface AuthResponse {
+  token: string;
+  user: User;
+}
+
+export const loginRequest = async (payload: LoginPayload): Promise<AuthResponse> => {
+  const { data } = await apiClient.post('/v1/auth/login', payload);
+  return data.data;
+};
+
+export const registerRequest = async (payload: RegisterPayload): Promise<AuthResponse> => {
+  const { data } = await apiClient.post('/v1/auth/register', payload);
+  return data.data;
+};
+
+export const logoutRequest = async (token: string) => {
+  await apiClient.post(
+    '/v1/auth/logout',
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }
+  );
+};
+
+export const getCurrentUser = async (token: string): Promise<User> => {
+  const { data } = await apiClient.get('/v1/auth/me', {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+  return data.data;
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: 'http://72.60.201.13:4000',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default apiClient;

--- a/src/api/instruments.ts
+++ b/src/api/instruments.ts
@@ -1,0 +1,14 @@
+import apiClient from './client';
+import type { Instrument } from '../types';
+
+export const searchInstruments = async (query: string): Promise<Instrument[]> => {
+  const { data } = await apiClient.get('/v1/instruments', {
+    params: { q: query, limit: 20 }
+  });
+  return data.data;
+};
+
+export const getInstrument = async (id: string): Promise<Instrument> => {
+  const { data } = await apiClient.get(`/v1/instruments/${id}`);
+  return data.data;
+};

--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,0 +1,14 @@
+import apiClient from './client';
+import type { Quote } from '../types';
+
+export const getQuote = async (instrumentId: string): Promise<Quote> => {
+  const { data } = await apiClient.get(`/v1/market/quote/${instrumentId}`);
+  return data.data;
+};
+
+export const getQuotes = async (instrumentIds: string[]): Promise<Quote[]> => {
+  const { data } = await apiClient.post('/v1/market/quotes', {
+    instrument_ids: instrumentIds
+  });
+  return data.data;
+};

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -1,0 +1,26 @@
+import apiClient from './client';
+import type { Order } from '../types';
+
+export interface OrderPayload {
+  instrument_id: string;
+  side: 'BUY' | 'SELL';
+  qty: number;
+  price?: number;
+  order_type: 'MARKET' | 'LIMIT';
+  product: 'MIS' | 'CNC';
+}
+
+export const placeOrder = async (payload: OrderPayload) => {
+  const { data } = await apiClient.post('/v1/orders', payload);
+  return data.data;
+};
+
+export const getOrders = async () => {
+  const { data } = await apiClient.get('/v1/orders');
+  return data.data as Order[];
+};
+
+export const cancelOrder = async (orderId: string) => {
+  const { data } = await apiClient.post(`/v1/orders/${orderId}/cancel`);
+  return data.data as Order;
+};

--- a/src/api/portfolio.ts
+++ b/src/api/portfolio.ts
@@ -1,0 +1,17 @@
+import apiClient from './client';
+import type { Holding, Position } from '../types';
+
+export const getHoldings = async () => {
+  const { data } = await apiClient.get('/v1/portfolio/holdings');
+  return data.data as Holding[];
+};
+
+export const getPositions = async () => {
+  const { data } = await apiClient.get('/v1/portfolio/positions');
+  return data.data as Position[];
+};
+
+export const getDailyPnl = async () => {
+  const { data } = await apiClient.get('/v1/portfolio/pnl/daily');
+  return data.data as { date: string; realized: number }[];
+};

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -1,0 +1,22 @@
+import apiClient from './client';
+import type { WalletSummary } from '../types';
+
+export const getWallet = async (): Promise<WalletSummary> => {
+  const { data } = await apiClient.get('/v1/wallet');
+  return data.data as WalletSummary;
+};
+
+export const getWalletTransactions = async () => {
+  const { data } = await apiClient.get('/v1/wallet/transactions');
+  return data.data as Array<{ id: string; amount: number; type: string; note?: string; createdAt: string }>;
+};
+
+export const creditWallet = async (payload: { user_id: string; amount: number; note?: string }) => {
+  const { data } = await apiClient.post('/v1/wallet/credit', payload);
+  return data.data;
+};
+
+export const debitWallet = async (payload: { user_id: string; amount: number; note?: string }) => {
+  const { data } = await apiClient.post('/v1/wallet/debit', payload);
+  return data.data;
+};

--- a/src/api/watchlists.ts
+++ b/src/api/watchlists.ts
@@ -1,0 +1,30 @@
+import apiClient from './client';
+import type { Watchlist } from '../types';
+
+export const getWatchlists = async () => {
+  const { data } = await apiClient.get('/v1/watchlists');
+  return data.data as Watchlist[];
+};
+
+export const createWatchlist = async (payload: { name: string }) => {
+  const { data } = await apiClient.post('/v1/watchlists', payload);
+  return data.data as Watchlist;
+};
+
+export const updateWatchlist = async (watchlistId: string, payload: { name?: string; reorder?: string[] }) => {
+  const { data } = await apiClient.put(`/v1/watchlists/${watchlistId}`, payload);
+  return data.data as Watchlist;
+};
+
+export const deleteWatchlist = async (watchlistId: string) => {
+  await apiClient.delete(`/v1/watchlists/${watchlistId}`);
+};
+
+export const addWatchlistItem = async (watchlistId: string, payload: { instrument_id: string }) => {
+  const { data } = await apiClient.post(`/v1/watchlists/${watchlistId}/items`, payload);
+  return data.data;
+};
+
+export const removeWatchlistItem = async (watchlistId: string, itemId: string) => {
+  await apiClient.delete(`/v1/watchlists/${watchlistId}/items/${itemId}`);
+};

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -1,0 +1,47 @@
+import { List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+interface NavItem {
+  icon: React.ReactNode;
+  label: string;
+  path: string;
+}
+
+interface SidebarNavProps {
+  items: NavItem[];
+  basePath: string;
+}
+
+const SidebarNav = ({ items, basePath }: SidebarNavProps) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return (
+    <List sx={{ px: 1 }}>
+      {items.map((item) => {
+        const isActive = location.pathname === item.path || location.pathname === `${basePath}${item.path}`;
+        return (
+          <ListItemButton
+            key={item.label}
+            selected={isActive}
+            onClick={() => navigate(item.path)}
+            sx={{
+              borderRadius: 2,
+              mb: 1,
+              color: 'rgba(255,255,255,0.8)',
+              '&.Mui-selected': {
+                background: 'linear-gradient(135deg, rgba(56,182,255,0.25), rgba(100,255,218,0.15))',
+                color: '#fff'
+              }
+            }}
+          >
+            <ListItemIcon sx={{ color: 'inherit', minWidth: 42 }}>{item.icon}</ListItemIcon>
+            <ListItemText primary={item.label} />
+          </ListItemButton>
+        );
+      })}
+    </List>
+  );
+};
+
+export default SidebarNav;

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,52 @@
+import { Box, Typography } from '@mui/material';
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  change?: string;
+  icon?: React.ReactNode;
+}
+
+const StatCard = ({ title, value, change, icon }: StatCardProps) => (
+  <Box
+    sx={{
+      p: 3,
+      borderRadius: 3,
+      background: 'linear-gradient(145deg, rgba(23,32,56,0.9), rgba(15,23,42,0.9))',
+      border: '1px solid rgba(56,182,255,0.2)',
+      display: 'flex',
+      alignItems: 'center',
+      gap: 2
+    }}
+  >
+    <Box
+      sx={{
+        width: 48,
+        height: 48,
+        borderRadius: 2,
+        background: 'rgba(56,182,255,0.12)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'primary.main'
+      }}
+    >
+      {icon}
+    </Box>
+    <Box>
+      <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+        {title}
+      </Typography>
+      <Typography variant="h5" sx={{ fontWeight: 700, mt: 0.5 }}>
+        {value}
+      </Typography>
+      {change && (
+        <Typography variant="caption" color={change.startsWith('-') ? 'error.light' : 'secondary.light'}>
+          {change}
+        </Typography>
+      )}
+    </Box>
+  </Box>
+);
+
+export default StatCard;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,114 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getCurrentUser, loginRequest, logoutRequest, registerRequest } from '../api/auth';
+import type { LoginPayload, RegisterPayload, User } from '../types';
+
+interface AuthContextValue {
+  token: string | null;
+  user: User | null;
+  loading: boolean;
+  login: (payload: LoginPayload) => Promise<void>;
+  register: (payload: RegisterPayload) => Promise<void>;
+  logout: () => Promise<void>;
+  refreshProfile: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const navigate = useNavigate();
+  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      if (token) {
+        try {
+          const profile = await getCurrentUser(token);
+          setUser(profile);
+        } catch (error) {
+          console.error('Failed to load profile', error);
+          setToken(null);
+          localStorage.removeItem('token');
+        }
+      }
+      setLoading(false);
+    };
+
+    bootstrap();
+  }, [token]);
+
+  const login = useCallback(
+    async (payload: LoginPayload) => {
+      setLoading(true);
+      try {
+        const { token: authToken, user: loggedUser } = await loginRequest(payload);
+        setToken(authToken);
+        setUser(loggedUser);
+        localStorage.setItem('token', authToken);
+        navigate(loggedUser.roles.includes('admin') ? '/admin' : '/app');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate]
+  );
+
+  const register = useCallback(
+    async (payload: RegisterPayload) => {
+      setLoading(true);
+      try {
+        const { token: authToken, user: registeredUser } = await registerRequest(payload);
+        setToken(authToken);
+        setUser(registeredUser);
+        localStorage.setItem('token', authToken);
+        navigate('/app');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate]
+  );
+
+  const logout = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      await logoutRequest(token);
+    } catch (error) {
+      console.warn('Failed to call logout endpoint', error);
+    } finally {
+      setToken(null);
+      setUser(null);
+      localStorage.removeItem('token');
+      setLoading(false);
+      navigate('/');
+    }
+  }, [navigate, token]);
+
+  const refreshProfile = useCallback(async () => {
+    if (!token) return;
+    try {
+      const profile = await getCurrentUser(token);
+      setUser(profile);
+    } catch (error) {
+      console.error('Failed to refresh profile', error);
+    }
+  }, [token]);
+
+  const value = useMemo(
+    () => ({ token, user, loading, login, register, logout, refreshProfile }),
+    [token, user, loading, login, register, logout, refreshProfile]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/hooks/useSnackbar.tsx
+++ b/src/hooks/useSnackbar.tsx
@@ -1,0 +1,15 @@
+import { useCallback, useState } from 'react';
+
+export const useSnackbar = () => {
+  const [message, setMessage] = useState<string | null>(null);
+  const [severity, setSeverity] = useState<'success' | 'error' | 'info' | 'warning'>('info');
+
+  const showMessage = useCallback((text: string, level: typeof severity = 'info') => {
+    setMessage(text);
+    setSeverity(level);
+  }, []);
+
+  const clearMessage = useCallback(() => setMessage(null), []);
+
+  return { message, severity, showMessage, clearMessage };
+};

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,58 @@
+import { Box, Button, Divider, Typography } from '@mui/material';
+import { Outlet, useNavigate } from 'react-router-dom';
+import DashboardIcon from '@mui/icons-material/Insights';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import StorageIcon from '@mui/icons-material/Storage';
+import SecurityIcon from '@mui/icons-material/Security';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import SidebarNav from '../components/SidebarNav';
+import { useAuth } from '../context/AuthContext';
+
+const navItems = [
+  { icon: <PeopleAltIcon />, label: 'Users', path: '/admin' },
+  { icon: <StorageIcon />, label: 'Instruments', path: '/admin/instruments' },
+  { icon: <AccountBalanceWalletIcon />, label: 'Wallet Ops', path: '/admin/wallet' },
+  { icon: <DashboardIcon />, label: 'System', path: '/admin/system' },
+  { icon: <SecurityIcon />, label: 'Access Tokens', path: '/admin/access-tokens' }
+];
+
+const AdminLayout = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <Box
+        component="aside"
+        sx={{
+          width: 280,
+          px: 3,
+          py: 4,
+          borderRight: '1px solid rgba(56,182,255,0.2)',
+          background: 'rgba(6,8,14,0.95)',
+          backdropFilter: 'blur(18px)',
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column'
+        }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 4 }}>
+          SkyTrade Admin
+        </Typography>
+        <SidebarNav items={navItems} basePath="/admin" />
+        <Box sx={{ flexGrow: 1 }} />
+        <Divider sx={{ my: 2, borderColor: 'rgba(255,255,255,0.08)' }} />
+        <Button variant="outlined" color="secondary" fullWidth sx={{ mb: 1 }} onClick={() => navigate('/app')}>
+          Back to client
+        </Button>
+        <Button variant="contained" color="primary" fullWidth onClick={logout}>
+          Log out
+        </Button>
+      </Box>
+      <Box component="main" sx={{ flex: 1, p: { xs: 2, md: 4 } }}>
+        <Outlet />
+      </Box>
+    </Box>
+  );
+};
+
+export default AdminLayout;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,73 @@
+import { Box, Button, Divider, Typography } from '@mui/material';
+import { Outlet, useNavigate } from 'react-router-dom';
+import DashboardIcon from '@mui/icons-material/SpaceDashboardRounded';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import SidebarNav from '../components/SidebarNav';
+import { useAuth } from '../context/AuthContext';
+
+const navItems = [
+  { icon: <DashboardIcon />, label: 'Overview', path: '/app' },
+  { icon: <ShowChartIcon />, label: 'Market', path: '/app/market' },
+  { icon: <ListAltIcon />, label: 'Orders', path: '/app/orders' },
+  { icon: <AssessmentIcon />, label: 'Portfolio', path: '/app/portfolio' },
+  { icon: <AccountBalanceWalletIcon />, label: 'Wallet', path: '/app/wallet' },
+  { icon: <PlaylistAddCheckIcon />, label: 'Watchlists', path: '/app/watchlists' }
+];
+
+const MainLayout = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <Box
+        component="aside"
+        sx={{
+          width: 280,
+          px: 3,
+          py: 4,
+          borderRight: '1px solid rgba(56,182,255,0.2)',
+          background: 'rgba(9,13,22,0.92)',
+          backdropFilter: 'blur(16px)',
+          display: { xs: 'none', md: 'flex' },
+          flexDirection: 'column'
+        }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 4 }}>
+          SkyTrade
+        </Typography>
+        <SidebarNav items={navItems} basePath="/app" />
+        <Box sx={{ flexGrow: 1 }} />
+        <Divider sx={{ my: 2, borderColor: 'rgba(255,255,255,0.08)' }} />
+        <Box>
+          <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', mb: 1 }}>
+            {user?.email}
+          </Typography>
+          {user?.roles.includes('admin') && (
+            <Button
+              variant="outlined"
+              color="secondary"
+              fullWidth
+              onClick={() => navigate('/admin')}
+              sx={{ mb: 1 }}
+            >
+              Admin Console
+            </Button>
+          )}
+          <Button variant="contained" color="primary" fullWidth onClick={logout}>
+            Log out
+          </Button>
+        </Box>
+      </Box>
+      <Box component="main" sx={{ flex: 1, p: { xs: 2, md: 4 }, maxWidth: '100%' }}>
+        <Outlet />
+      </Box>
+    </Box>
+  );
+};
+
+export default MainLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CssBaseline, ThemeProvider } from '@mui/material';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import App from './App';
+import theme from './styles/theme';
+import './styles/global.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/pages/admin/AdminAccessTokensPage.tsx
+++ b/src/pages/admin/AdminAccessTokensPage.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+
+const AdminAccessTokensPage = () => {
+  const [description, setDescription] = useState('');
+  const [token, setToken] = useState<string>('');
+
+  const handleGenerate = () => {
+    const generated = crypto.randomUUID();
+    setToken(generated);
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Access tokens
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Generate scoped tokens for integrations, APIs, and automation clients.
+        </Typography>
+      </Box>
+      <Card>
+        <CardContent>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <TextField
+                label="Description"
+                placeholder="OMS integration"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField label="Token" value={token} fullWidth InputProps={{ readOnly: true }} />
+            </Grid>
+            <Grid item xs={12}>
+              <Button variant="contained" onClick={handleGenerate}>
+                Generate new token
+              </Button>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default AdminAccessTokensPage;

--- a/src/pages/admin/AdminInstrumentsPage.tsx
+++ b/src/pages/admin/AdminInstrumentsPage.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+
+const AdminInstrumentsPage = () => {
+  const [fileName, setFileName] = useState<string>('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    setMessage(`Ready to import ${file.name}. Submit to push to the master instrument list.`);
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Instrument catalogue
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Upload broker tokens, manage exchange mappings, and refresh the instrument universe.
+        </Typography>
+      </Box>
+      <Card>
+        <CardContent>
+          <Stack spacing={3}>
+            <Box>
+              <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                Import CSV
+              </Typography>
+              <Button component="label" variant="outlined" startIcon={<CloudUploadIcon />}>
+                Select file
+                <input type="file" hidden accept=".csv" onChange={handleFileChange} />
+              </Button>
+              {fileName && (
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', mt: 1 }}>
+                  {fileName}
+                </Typography>
+              )}
+            </Box>
+            <TextField label="Broker" placeholder="zerodha" fullWidth />
+            <TextField label="Token column" placeholder="instrument_token" fullWidth />
+            <Button variant="contained" color="primary">
+              Import instruments
+            </Button>
+            {message && <Alert severity="info">{message}</Alert>}
+          </Stack>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default AdminInstrumentsPage;

--- a/src/pages/admin/AdminSystemPage.tsx
+++ b/src/pages/admin/AdminSystemPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { Box, Card, CardContent, Grid, LinearProgress, Stack, Typography } from '@mui/material';
+import InsightsIcon from '@mui/icons-material/Insights';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import StatCard from '../../components/StatCard';
+import { getAdminOrders, getAdminTrades, getSystemStats } from '../../api/admin';
+
+const AdminSystemPage = () => {
+  const [stats, setStats] = useState<{ totalUsers: number; activeOrders: number; tradesToday: number; serverLoad: number } | null>(
+    null
+  );
+  const [ordersCount, setOrdersCount] = useState<number>(0);
+  const [tradesCount, setTradesCount] = useState<number>(0);
+
+  useEffect(() => {
+    getSystemStats()
+      .then(setStats)
+      .catch((error) => console.error('Failed to load stats', error));
+    getAdminOrders()
+      .then((data) => setOrdersCount(data.length))
+      .catch((error) => console.error('Failed to load orders', error));
+    getAdminTrades()
+      .then((data) => setTradesCount(data.length))
+      .catch((error) => console.error('Failed to load trades', error));
+  }, []);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          System telemetry
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Monitor backend health, execution loads, and trading activity in real-time.
+        </Typography>
+      </Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Total users" value={stats?.totalUsers ?? 0} icon={<InsightsIcon />} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Active orders" value={stats?.activeOrders ?? 0} icon={<TimelineIcon />} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Trades today" value={stats?.tradesToday ?? 0} icon={<ShowChartIcon />} />
+        </Grid>
+      </Grid>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Server load
+          </Typography>
+          <LinearProgress variant="determinate" value={stats?.serverLoad ?? 0} sx={{ height: 12, borderRadius: 6 }} />
+          <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', mt: 1 }}>
+            {stats?.serverLoad ?? 0}% utilisation across trading clusters
+          </Typography>
+        </CardContent>
+      </Card>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Orders processed
+              </Typography>
+              <Typography variant="h3" sx={{ fontWeight: 700 }}>
+                {ordersCount}
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                Total orders processed in the system
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                Trades executed
+              </Typography>
+              <Typography variant="h3" sx={{ fontWeight: 700 }}>
+                {tradesCount}
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                Total trades executed across all venues
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+};
+
+export default AdminSystemPage;

--- a/src/pages/admin/AdminUsersPage.tsx
+++ b/src/pages/admin/AdminUsersPage.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { approveUser, blockUser, getUsers, unblockUser } from '../../api/admin';
+import type { User } from '../../types';
+
+const AdminUsersPage = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadUsers = () => {
+    setLoading(true);
+    getUsers()
+      .then(setUsers)
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const handleApprove = async (userId: string) => {
+    await approveUser(userId);
+    loadUsers();
+  };
+
+  const handleBlock = async (userId: string, block: boolean) => {
+    if (block) {
+      await blockUser(userId);
+    } else {
+      await unblockUser(userId);
+    }
+    loadUsers();
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          User management
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Approve onboarding requests, manage access, and control operational risk.
+        </Typography>
+      </Box>
+      <Card>
+        <CardContent>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell>Roles</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {users.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.name}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={1}>
+                      {user.roles.map((role) => (
+                        <Chip key={role} label={role} color={role === 'admin' ? 'secondary' : 'default'} />
+                      ))}
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={user.approved ? 'Approved' : 'Pending'}
+                      color={user.approved ? 'success' : 'warning'}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    <Stack direction="row" spacing={1} justifyContent="flex-end">
+                      {!user.approved && (
+                        <Button size="small" variant="contained" onClick={() => handleApprove(user.id)}>
+                          Approve
+                        </Button>
+                      )}
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color={user.isBlocked ? 'success' : 'error'}
+                        onClick={() => handleBlock(user.id, !user.isBlocked)}
+                      >
+                        {user.isBlocked ? 'Unblock' : 'Block'}
+                      </Button>
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!users.length && !loading && (
+                <TableRow>
+                  <TableCell colSpan={5}>
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', textAlign: 'center' }}>
+                      No users yet. Onboard clients from the main registration flow.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default AdminUsersPage;

--- a/src/pages/admin/AdminWalletPage.tsx
+++ b/src/pages/admin/AdminWalletPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { creditWallet, debitWallet } from '../../api/wallet';
+
+const AdminWalletPage = () => {
+  const [userId, setUserId] = useState('');
+  const [amount, setAmount] = useState<number>(0);
+  const [note, setNote] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleWallet = async (action: 'credit' | 'debit') => {
+    if (!userId || !amount) return;
+    const payload = { user_id: userId, amount, note };
+    try {
+      if (action === 'credit') {
+        await creditWallet(payload);
+        setMessage(`Credited ₹${amount} to ${userId}`);
+      } else {
+        await debitWallet(payload);
+        setMessage(`Debited ₹${amount} from ${userId}`);
+      }
+    } catch (error) {
+      setMessage('Operation failed. Please verify user ID or permissions.');
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Wallet operations
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Credit or debit user wallets instantly with full audit trails.
+        </Typography>
+      </Box>
+      <Card>
+        <CardContent>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={4}>
+              <TextField label="User ID" value={userId} onChange={(event) => setUserId(event.target.value)} fullWidth />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField
+                label="Amount"
+                type="number"
+                value={amount}
+                onChange={(event) => setAmount(Number(event.target.value))}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField label="Note" value={note} onChange={(event) => setNote(event.target.value)} fullWidth />
+            </Grid>
+            <Grid item xs={12}>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                <Button variant="contained" color="primary" onClick={() => handleWallet('credit')}>
+                  Credit
+                </Button>
+                <Button variant="outlined" color="error" onClick={() => handleWallet('debit')}>
+                  Debit
+                </Button>
+              </Stack>
+            </Grid>
+          </Grid>
+          {message && (
+            <Alert severity="info" sx={{ mt: 3 }}>
+              {message}
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default AdminWalletPage;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useAuth } from '../../context/AuthContext';
+
+const LoginPage = () => {
+  const { login, loading } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      await login({ email, password });
+    } catch (err) {
+      setError('Unable to log in. Please check your credentials.');
+    }
+  };
+
+  return (
+    <Stack alignItems="center" justifyContent="center" sx={{ minHeight: '100vh', p: 2 }}>
+      <Card sx={{ maxWidth: 420, width: '100%' }}>
+        <CardContent>
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+            Welcome back
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)', mb: 4 }}>
+            Sign in with your SkyTrade credentials to access your trading cockpit.
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit}>
+            <Stack spacing={3}>
+              {error && <Alert severity="error">{error}</Alert>}
+              <TextField
+                label="Email address"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                fullWidth
+                required
+              />
+              <Button type="submit" variant="contained" size="large" disabled={loading}>
+                {loading ? <CircularProgress size={24} /> : 'Sign in'}
+              </Button>
+            </Stack>
+          </Box>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useAuth } from '../../context/AuthContext';
+
+const RegisterPage = () => {
+  const { register, loading } = useAuth();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      await register({ name, email, password });
+    } catch (err) {
+      setError('Unable to register. Please check details and try again.');
+    }
+  };
+
+  return (
+    <Stack alignItems="center" justifyContent="center" sx={{ minHeight: '100vh', p: 2 }}>
+      <Card sx={{ maxWidth: 600, width: '100%' }}>
+        <CardContent>
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+            Create your SkyTrade account
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)', mb: 4 }}>
+            Unlock lightning fast order execution, live portfolio analytics, and institutional tools designed for serious traders.
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit}>
+            <Grid container spacing={3}>
+              {error && (
+                <Grid item xs={12}>
+                  <Alert severity="error">{error}</Alert>
+                </Grid>
+              )}
+              <Grid item xs={12} md={6}>
+                <TextField label="Full name" value={name} onChange={(event) => setName(event.target.value)} fullWidth required />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField label="Email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} fullWidth required />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Password"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  fullWidth
+                  required
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Button type="submit" variant="contained" size="large" fullWidth disabled={loading}>
+                  {loading ? <CircularProgress size={24} /> : 'Create account'}
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default RegisterPage;

--- a/src/pages/client/ClientDashboard.tsx
+++ b/src/pages/client/ClientDashboard.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Card, CardContent, Grid, Stack, Typography } from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import { ResponsiveContainer, LineChart, Line, Tooltip, CartesianGrid, XAxis, YAxis, Area, AreaChart } from 'recharts';
+import StatCard from '../../components/StatCard';
+import { getDailyPnl } from '../../api/portfolio';
+import { getWallet } from '../../api/wallet';
+import { getOrders } from '../../api/orders';
+import type { Order, WalletSummary } from '../../types';
+
+const ClientDashboard = () => {
+  const [pnl, setPnl] = useState<{ date: string; realized: number }[]>([]);
+  const [wallet, setWallet] = useState<WalletSummary | null>(null);
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    getDailyPnl()
+      .then(setPnl)
+      .catch((error) => console.error('Failed to load pnl', error));
+    getWallet()
+      .then(setWallet)
+      .catch((error) => console.error('Failed to load wallet', error));
+    getOrders()
+      .then(setOrders)
+      .catch((error) => console.error('Failed to load orders', error));
+  }, []);
+
+  const latestPnL = useMemo(() => (pnl.length ? pnl[pnl.length - 1].realized : 0), [pnl]);
+
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Trading overview
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Monitor performance, risk, and execution metrics in real-time.
+        </Typography>
+      </Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={3}>
+          <StatCard title="Account Equity" value={`₹${(wallet?.balance ?? 0).toLocaleString()}`} change="Today +₹12,400" icon={<TrendingUpIcon />} />
+        </Grid>
+        <Grid item xs={12} md={3}>
+          <StatCard title="Available Margin" value={`₹${(wallet?.margin ?? 0).toLocaleString()}`} change="74% utilised" icon={<AccountBalanceWalletIcon />} />
+        </Grid>
+        <Grid item xs={12} md={3}>
+          <StatCard title="Open Orders" value={orders.length} change="Pending executions" icon={<ShowChartIcon />} />
+        </Grid>
+        <Grid item xs={12} md={3}>
+          <StatCard title="Realized P&L" value={`₹${latestPnL.toLocaleString()}`} change="Last sync" icon={<AssessmentIcon />} />
+        </Grid>
+      </Grid>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Daily Realized P&L
+              </Typography>
+              <Box sx={{ height: 280 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={pnl}>
+                    <defs>
+                      <linearGradient id="colorPnl" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#38b6ff" stopOpacity={0.8} />
+                        <stop offset="95%" stopColor="#38b6ff" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />
+                    <XAxis dataKey="date" stroke="rgba(255,255,255,0.54)" />
+                    <YAxis stroke="rgba(255,255,255,0.54)" />
+                    <Tooltip contentStyle={{ backgroundColor: '#111827', borderRadius: 12 }} />
+                    <Area type="monotone" dataKey="realized" stroke="#38b6ff" fillOpacity={1} fill="url(#colorPnl)" />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Execution velocity
+              </Typography>
+              <Box sx={{ height: 280 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={orders.slice(0, 10)}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />
+                    <XAxis dataKey="createdAt" hide />
+                    <YAxis hide />
+                    <Tooltip contentStyle={{ backgroundColor: '#111827', borderRadius: 12 }} labelFormatter={() => 'Order'} />
+                    <Line type="monotone" dataKey="qty" stroke="#64ffda" strokeWidth={3} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+};
+
+export default ClientDashboard;

--- a/src/pages/client/LandingPage.tsx
+++ b/src/pages/client/LandingPage.tsx
@@ -1,0 +1,84 @@
+import { Box, Button, Container, Grid, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import SecurityIcon from '@mui/icons-material/Security';
+import TimelineIcon from '@mui/icons-material/Timeline';
+
+const LandingPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', py: 8 }}>
+      <Container maxWidth="lg">
+        <Grid container spacing={6} alignItems="center">
+          <Grid item xs={12} md={6}>
+            <Typography variant="h2" sx={{ fontWeight: 700, mb: 2 }}>
+              Trade smarter with SkyTrade
+            </Typography>
+            <Typography variant="h6" sx={{ color: 'rgba(255,255,255,0.6)', mb: 4 }}>
+              Institutional-grade trading, risk analytics, and seamless execution in a single, modern interface.
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+              <Button size="large" variant="contained" onClick={() => navigate('/login')}>
+                Launch Trading Terminal
+              </Button>
+              <Button size="large" variant="outlined" color="secondary" onClick={() => navigate('/register')}>
+                Create Account
+              </Button>
+            </Box>
+            <Box sx={{ mt: 6, display: 'grid', gap: 3, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+              {[{ icon: <ShowChartIcon />, title: 'Advanced Charts', desc: 'Real-time quotes and charting with 25+ indicators.' },
+                { icon: <SecurityIcon />, title: 'Secure Access', desc: 'Bank-grade security with granular admin controls.' },
+                { icon: <TimelineIcon />, title: 'Live P&L', desc: 'Live portfolio and risk monitoring with alerts.' }].map((feature) => (
+                <Box key={feature.title} sx={{ p: 3, borderRadius: 3, background: 'rgba(17,24,39,0.8)', border: '1px solid rgba(56,182,255,0.2)' }}>
+                  <Box sx={{ color: 'primary.main', mb: 1 }}>{feature.icon}</Box>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {feature.title}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                    {feature.desc}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Box
+              sx={{
+                borderRadius: 4,
+                p: 4,
+                background: 'linear-gradient(160deg, rgba(56,182,255,0.18), rgba(100,255,218,0.08))',
+                border: '1px solid rgba(56,182,255,0.3)',
+                boxShadow: '0 30px 80px rgba(2,6,23,0.55)',
+                position: 'relative'
+              }}
+            >
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Live performance snapshot
+              </Typography>
+              <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}>
+                {[{ label: 'Equity', value: '₹12,45,000', change: '+4.5%' }, { label: 'Day P&L', value: '+₹23,400', change: '+2.1%' }, { label: 'Margin Available', value: '₹6,80,000', change: '72%' }, { label: 'Open Positions', value: '12', change: '5 Long / 7 Short' }].map(
+                  (stat) => (
+                    <Box key={stat.label} sx={{ background: 'rgba(11,17,29,0.85)', borderRadius: 3, p: 3, border: '1px solid rgba(100,255,218,0.2)' }}>
+                      <Typography variant="caption" sx={{ textTransform: 'uppercase', letterSpacing: 1 }}>
+                        {stat.label}
+                      </Typography>
+                      <Typography variant="h5" sx={{ fontWeight: 700, mt: 1 }}>
+                        {stat.value}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: 'secondary.light' }}>
+                        {stat.change}
+                      </Typography>
+                    </Box>
+                  )
+                )}
+              </Box>
+            </Box>
+          </Grid>
+        </Grid>
+      </Container>
+    </Box>
+  );
+};
+
+export default LandingPage;

--- a/src/pages/client/MarketExplorer.tsx
+++ b/src/pages/client/MarketExplorer.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
+import BoltIcon from '@mui/icons-material/Bolt';
+import { searchInstruments } from '../../api/instruments';
+import { getQuote } from '../../api/market';
+import type { Instrument, Quote } from '../../types';
+
+const MarketExplorer = () => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Instrument[]>([]);
+  const [quotes, setQuotes] = useState<Record<string, Quote>>({});
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      searchInstruments(query)
+        .then(setResults)
+        .catch((error) => console.error('Instrument search failed', error));
+    }, 400);
+    return () => clearTimeout(timeout);
+  }, [query]);
+
+  useEffect(() => {
+    const loadQuotes = async () => {
+      const entries = await Promise.all(
+        results.slice(0, 5).map(async (instrument) => {
+          try {
+            const quote = await getQuote(instrument.id);
+            return [instrument.id, quote] as const;
+          } catch (error) {
+            console.error('Failed to fetch quote', error);
+            return [instrument.id, undefined] as const;
+          }
+        })
+      );
+      setQuotes(Object.fromEntries(entries.filter((entry): entry is [string, Quote] => Boolean(entry[1]))));
+    };
+
+    if (results.length) {
+      loadQuotes();
+    }
+  }, [results]);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Market Explorer
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Search across exchanges, track quotes in real-time, and push instruments into watchlists instantly.
+        </Typography>
+      </Box>
+      <Card>
+        <CardContent>
+          <TextField
+            placeholder="Search instruments, symbols, ISIN..."
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+              sx: { borderRadius: 3 }
+            }}
+          />
+        </CardContent>
+      </Card>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography variant="h6">Search results</Typography>
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                  {results.length} instruments
+                </Typography>
+              </Stack>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Symbol</TableCell>
+                    <TableCell>Exchange</TableCell>
+                    <TableCell>Segment</TableCell>
+                    <TableCell>Type</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {results.map((instrument) => (
+                    <TableRow key={instrument.id}>
+                      <TableCell>
+                        <Stack direction="row" spacing={2} alignItems="center">
+                          <Avatar sx={{ bgcolor: 'rgba(56,182,255,0.2)', color: 'primary.main' }}>
+                            {instrument.tradingsymbol[0]}
+                          </Avatar>
+                          <Box>
+                            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                              {instrument.tradingsymbol}
+                            </Typography>
+                            <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                              {instrument.name}
+                            </Typography>
+                          </Box>
+                        </Stack>
+                      </TableCell>
+                      <TableCell>{instrument.exchange}</TableCell>
+                      <TableCell>{instrument.segment}</TableCell>
+                      <TableCell>{instrument.type}</TableCell>
+                      <TableCell align="right">
+                        <Stack direction="row" spacing={1} justifyContent="flex-end">
+                          <Button variant="outlined" size="small" startIcon={<BoltIcon />}>
+                            Trade
+                          </Button>
+                          <IconButton color="secondary">
+                            <PlaylistAddIcon />
+                          </IconButton>
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Live quotes
+              </Typography>
+              <Stack spacing={2}>
+                {Object.values(quotes).map((quote) => (
+                  <Box key={quote.instrument_id} sx={{ p: 2, borderRadius: 3, background: 'rgba(15,23,42,0.75)', border: '1px solid rgba(148,163,184,0.18)' }}>
+                    <Typography variant="subtitle2">{quote.instrument_id}</Typography>
+                    <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                      {quote.ltp.toFixed(2)}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'secondary.light' }}>
+                      Bid {quote.bid.toFixed(2)} / Ask {quote.ask.toFixed(2)}
+                    </Typography>
+                  </Box>
+                ))}
+                {!Object.values(quotes).length && (
+                  <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                    Search to view live quotes summary.
+                  </Typography>
+                )}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+};
+
+export default MarketExplorer;

--- a/src/pages/client/OrdersPage.tsx
+++ b/src/pages/client/OrdersPage.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  MenuItem,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useForm } from 'react-hook-form';
+import { getOrders, placeOrder } from '../../api/orders';
+import { searchInstruments } from '../../api/instruments';
+import type { Order } from '../../types';
+
+interface NewOrderForm {
+  instrument_id: string;
+  side: 'BUY' | 'SELL';
+  qty: number;
+  price?: number;
+  order_type: 'MARKET' | 'LIMIT';
+  product: 'CNC' | 'MIS';
+}
+
+const OrdersPage = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [open, setOpen] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [symbolQuery, setSymbolQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<{ id: string; label: string }[]>([]);
+  const { register, handleSubmit, reset, setValue } = useForm<NewOrderForm>({
+    defaultValues: { side: 'BUY', order_type: 'LIMIT', product: 'CNC' }
+  });
+
+  const fetchOrders = () => {
+    getOrders()
+      .then(setOrders)
+      .catch((error) => console.error('Failed to load orders', error));
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  useEffect(() => {
+    if (!symbolQuery) {
+      setSuggestions([]);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      searchInstruments(symbolQuery)
+        .then((data) => setSuggestions(data.map((instrument) => ({ id: instrument.id, label: instrument.tradingsymbol }))))
+        .catch((error) => console.error('Instrument search failed', error));
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [symbolQuery]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await placeOrder(values);
+      setOpen(false);
+      reset();
+      setSubmitError(null);
+      fetchOrders();
+    } catch (error) {
+      console.error('Failed to place order', error);
+      setSubmitError('Order placement failed. Please verify details and try again.');
+    }
+  });
+
+  return (
+    <Stack spacing={3}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box>
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+            Orders
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+            Review open and completed orders, manage execution, and raise new orders quickly.
+          </Typography>
+        </Box>
+        <Button variant="contained" onClick={() => setOpen(true)}>
+          New Order
+        </Button>
+      </Box>
+      <Card>
+        <CardContent>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Order ID</TableCell>
+                <TableCell>Instrument</TableCell>
+                <TableCell>Side</TableCell>
+                <TableCell>Quantity</TableCell>
+                <TableCell>Price</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Placed</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {orders.map((order) => (
+                <TableRow key={order.id}>
+                  <TableCell>{order.id}</TableCell>
+                  <TableCell>{order.instrument_id}</TableCell>
+                  <TableCell>
+                    <Chip label={order.side} color={order.side === 'BUY' ? 'success' : 'error'} variant="outlined" />
+                  </TableCell>
+                  <TableCell>{order.qty}</TableCell>
+                  <TableCell>{order.price ?? 'Market'}</TableCell>
+                  <TableCell>
+                    <Chip label={order.status} color={order.status === 'OPEN' ? 'info' : 'default'} variant="outlined" />
+                  </TableCell>
+                  <TableCell>{new Date(order.createdAt).toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+              {!orders.length && (
+                <TableRow>
+                  <TableCell colSpan={7}>
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', textAlign: 'center' }}>
+                      No orders yet. Place your first trade to see it listed here.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Raise new order</DialogTitle>
+        <DialogContent>
+          <Stack spacing={3} sx={{ mt: 1 }}>
+            {submitError && <Alert severity="error">{submitError}</Alert>}
+            <TextField
+              label="Instrument symbol"
+              value={symbolQuery}
+              onChange={(event) => setSymbolQuery(event.target.value)}
+              helperText="Start typing to search instruments"
+              fullWidth
+            />
+            {suggestions.length > 0 && (
+              <Card variant="outlined">
+                <CardContent>
+                  <Stack spacing={1}>
+                    {suggestions.map((suggestion) => (
+                      <Button
+                        key={suggestion.id}
+                        variant="text"
+                        onClick={() => {
+                          setValue('instrument_id', suggestion.id, { shouldDirty: true, shouldTouch: true });
+                          setSymbolQuery(suggestion.label);
+                          setSuggestions([]);
+                        }}
+                      >
+                        {suggestion.label}
+                      </Button>
+                    ))}
+                  </Stack>
+                </CardContent>
+              </Card>
+            )}
+            <TextField label="Instrument ID" {...register('instrument_id')} required fullWidth />
+            <Grid container spacing={2}>
+              <Grid item xs={6}>
+                <TextField select label="Side" {...register('side')} fullWidth>
+                  <MenuItem value="BUY">Buy</MenuItem>
+                  <MenuItem value="SELL">Sell</MenuItem>
+                </TextField>
+              </Grid>
+              <Grid item xs={6}>
+                <TextField select label="Product" {...register('product')} fullWidth>
+                  <MenuItem value="CNC">Delivery (CNC)</MenuItem>
+                  <MenuItem value="MIS">Intraday (MIS)</MenuItem>
+                </TextField>
+              </Grid>
+            </Grid>
+            <Grid container spacing={2}>
+              <Grid item xs={6}>
+                <TextField label="Quantity" type="number" {...register('qty', { valueAsNumber: true })} fullWidth />
+              </Grid>
+              <Grid item xs={6}>
+                <TextField select label="Order Type" {...register('order_type')} fullWidth>
+                  <MenuItem value="MARKET">Market</MenuItem>
+                  <MenuItem value="LIMIT">Limit</MenuItem>
+                </TextField>
+              </Grid>
+            </Grid>
+            <TextField label="Price" type="number" {...register('price', { valueAsNumber: true })} fullWidth />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={onSubmit}>
+            Submit order
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default OrdersPage;

--- a/src/pages/client/PortfolioPage.tsx
+++ b/src/pages/client/PortfolioPage.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { ResponsiveContainer, BarChart, Bar, Tooltip, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { getHoldings, getPositions } from '../../api/portfolio';
+import type { Holding, Position } from '../../types';
+
+const PortfolioPage = () => {
+  const [holdings, setHoldings] = useState<Holding[]>([]);
+  const [positions, setPositions] = useState<Position[]>([]);
+
+  useEffect(() => {
+    getHoldings()
+      .then(setHoldings)
+      .catch((error) => console.error('Failed to load holdings', error));
+    getPositions()
+      .then(setPositions)
+      .catch((error) => console.error('Failed to load positions', error));
+  }, []);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Portfolio analytics
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          See concentration, mark-to-market gains, and overnight exposure.
+        </Typography>
+      </Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={7}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Holdings
+              </Typography>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Instrument</TableCell>
+                    <TableCell>Qty</TableCell>
+                    <TableCell>Avg Price</TableCell>
+                    <TableCell>P&L</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {holdings.map((holding) => (
+                    <TableRow key={holding.instrument_id}>
+                      <TableCell>{holding.instrument_id}</TableCell>
+                      <TableCell>{holding.qty}</TableCell>
+                      <TableCell>{holding.avg_price.toFixed(2)}</TableCell>
+                      <TableCell>
+                        <Chip
+                          label={(holding.pnl ?? 0).toFixed(2)}
+                          color={(holding.pnl ?? 0) >= 0 ? 'success' : 'error'}
+                          variant="outlined"
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {!holdings.length && (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', textAlign: 'center' }}>
+                          No holdings yet. Execute delivery trades to populate this view.
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={5}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Exposure by instrument
+              </Typography>
+              <Box sx={{ height: 320 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={positions}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />
+                    <XAxis dataKey="instrument_id" stroke="rgba(255,255,255,0.54)" />
+                    <YAxis stroke="rgba(255,255,255,0.54)" />
+                    <Tooltip contentStyle={{ backgroundColor: '#111827', borderRadius: 12 }} />
+                    <Bar dataKey="qty" fill="#38b6ff" radius={[8, 8, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+};
+
+export default PortfolioPage;

--- a/src/pages/client/WalletPage.tsx
+++ b/src/pages/client/WalletPage.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { Box, Card, CardContent, Grid, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import SavingsIcon from '@mui/icons-material/Savings';
+import StatCard from '../../components/StatCard';
+import { getWallet, getWalletTransactions } from '../../api/wallet';
+import type { WalletSummary } from '../../types';
+
+const WalletPage = () => {
+  const [wallet, setWallet] = useState<WalletSummary | null>(null);
+  const [transactions, setTransactions] = useState<Array<{ id: string; amount: number; type: string; note?: string; createdAt: string }>>([]);
+
+  useEffect(() => {
+    getWallet()
+      .then(setWallet)
+      .catch((error) => console.error('Failed to load wallet', error));
+    getWalletTransactions()
+      .then(setTransactions)
+      .catch((error) => console.error('Failed to load wallet transactions', error));
+  }, []);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          Wallet & Margin
+        </Typography>
+        <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          Track available funds, margin utilization, and capital allocation.
+        </Typography>
+      </Box>
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Balance" value={`₹${(wallet?.balance ?? 0).toLocaleString()}`} change="Net of charges" icon={<AccountBalanceWalletIcon />} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Margin" value={`₹${(wallet?.margin ?? 0).toLocaleString()}`} change="Intraday exposure" icon={<TimelineIcon />} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <StatCard title="Collateral" value={`₹${(wallet?.collateral ?? 0).toLocaleString()}`} change="Pledged securities" icon={<SavingsIcon />} />
+        </Grid>
+      </Grid>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Transactions
+          </Typography>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>ID</TableCell>
+                <TableCell>Amount</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Note</TableCell>
+                <TableCell>Time</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {transactions.map((transaction) => (
+                <TableRow key={transaction.id}>
+                  <TableCell>{transaction.id}</TableCell>
+                  <TableCell>{transaction.amount.toFixed(2)}</TableCell>
+                  <TableCell>{transaction.type}</TableCell>
+                  <TableCell>{transaction.note ?? '-'}</TableCell>
+                  <TableCell>{new Date(transaction.createdAt).toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+              {!transactions.length && (
+                <TableRow>
+                  <TableCell colSpan={5}>
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', textAlign: 'center' }}>
+                      No wallet transactions yet.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+};
+
+export default WalletPage;

--- a/src/pages/client/WatchlistsPage.tsx
+++ b/src/pages/client/WatchlistsPage.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import { createWatchlist, deleteWatchlist, getWatchlists } from '../../api/watchlists';
+import type { Watchlist } from '../../types';
+
+const WatchlistsPage = () => {
+  const [watchlists, setWatchlists] = useState<Watchlist[]>([]);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+
+  const loadWatchlists = () => {
+    getWatchlists()
+      .then(setWatchlists)
+      .catch((error) => console.error('Failed to load watchlists', error));
+  };
+
+  useEffect(() => {
+    loadWatchlists();
+  }, []);
+
+  const handleCreate = async () => {
+    await createWatchlist({ name });
+    setOpen(false);
+    setName('');
+    loadWatchlists();
+  };
+
+  const handleDelete = async (watchlistId: string) => {
+    await deleteWatchlist(watchlistId);
+    loadWatchlists();
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box>
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+            Watchlists
+          </Typography>
+          <Typography variant="body1" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+            Organize instruments by strategy, asset class, or timeframe.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setOpen(true)}>
+          Create watchlist
+        </Button>
+      </Box>
+      <Grid container spacing={3}>
+        {watchlists.map((watchlist) => (
+          <Grid item xs={12} md={6} key={watchlist.id}>
+            <Card>
+              <CardContent>
+                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+                  <Typography variant="h6">{watchlist.name}</Typography>
+                  <IconButton color="error" onClick={() => handleDelete(watchlist.id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </Stack>
+                <Stack spacing={2}>
+                  {watchlist.items.map((item) => (
+                    <Box key={item.id} sx={{ p: 2, borderRadius: 2, background: 'rgba(15,23,42,0.78)', border: '1px solid rgba(56,182,255,0.2)' }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                        {item.instrument?.tradingsymbol ?? item.instrument_id}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                        {item.instrument?.name ?? 'Instrument'}
+                      </Typography>
+                    </Box>
+                  ))}
+                  {!watchlist.items.length && (
+                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                      No instruments yet. Use the Market Explorer to add symbols quickly.
+                    </Typography>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+        {!watchlists.length && (
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)' }}>
+                  No watchlists created yet. Start by creating a list for your favourite trades.
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+      </Grid>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>New watchlist</DialogTitle>
+        <DialogContent>
+          <TextField label="Name" value={name} onChange={(event) => setName(event.target.value)} fullWidth sx={{ mt: 1 }} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default WatchlistsPage;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top left, rgba(56, 182, 255, 0.12), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(100, 255, 218, 0.12), transparent 45%),
+    #05070d;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,43 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#38b6ff'
+    },
+    secondary: {
+      main: '#64ffda'
+    },
+    background: {
+      default: '#0b101a',
+      paper: '#111827'
+    }
+  },
+  typography: {
+    fontFamily: 'Inter, sans-serif'
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 10,
+          textTransform: 'none',
+          fontWeight: 600
+        }
+      }
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+          backgroundImage: 'linear-gradient(145deg, rgba(21,27,41,0.95), rgba(10,13,20,0.9))',
+          border: '1px solid rgba(99, 102, 241, 0.12)',
+          boxShadow: '0 18px 45px rgba(15,23,42,0.45)'
+        }
+      }
+    }
+  }
+});
+
+export default theme;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,90 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  roles: string[];
+  approved: boolean;
+  isBlocked: boolean;
+  profile?: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload extends LoginPayload {
+  name: string;
+}
+
+export interface Instrument {
+  id: string;
+  name: string;
+  tradingsymbol: string;
+  exchange: string;
+  segment: string;
+  type: string;
+}
+
+export interface Quote {
+  instrument_id: string;
+  ltp: number;
+  bid: number;
+  ask: number;
+  ts: string;
+}
+
+export interface Order {
+  id: string;
+  instrument_id: string;
+  side: 'BUY' | 'SELL';
+  qty: number;
+  price: number;
+  order_type: string;
+  product: string;
+  status: string;
+  createdAt: string;
+}
+
+export interface Holding {
+  instrument_id: string;
+  qty: number;
+  avg_price: number;
+  pnl?: number;
+}
+
+export interface Position {
+  instrument_id: string;
+  qty: number;
+  avg_price: number;
+  product: string;
+  pnl?: number;
+}
+
+export interface WalletSummary {
+  balance: number;
+  margin: number;
+  collateral: number;
+  updatedAt: string;
+}
+
+export interface Watchlist {
+  id: string;
+  name: string;
+  items: WatchlistItem[];
+}
+
+export interface WatchlistItem {
+  id: string;
+  instrument_id: string;
+  instrument?: Instrument;
+}
+
+export interface ApiError {
+  error: {
+    code: string;
+    message: string;
+  };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript front-end with Material UI theming for the SkyTrade trading experience
- implement authenticated client workspace covering dashboard analytics, market explorer, orders, portfolio, wallet, and watchlists
- add dedicated admin console screens for user approvals, instrument imports, wallet operations, system telemetry, and access token generation

## Testing
- npm install *(fails: 403 Forbidden when downloading packages from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a251fc808331b8f75c4ac4cf4525